### PR TITLE
Improve UI and add NZ spaces

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -7,6 +7,7 @@ import HowItWorks from './pages/HowItWorks';
 import HostSpace from './pages/HostSpace';
 import AuthForm from './pages/AuthForm';
 import { featuredSpaces } from './data/mockData';
+import { formatCurrency } from './utils/format';
 import './App.css';
 
 function App() {
@@ -139,7 +140,7 @@ function App() {
                                                         color: '#1a202c',
                                                         fontFamily: 'Inter, sans-serif'
                                                     }}>
-                                                        ${space.price}
+                                                        {formatCurrency(space.price)}
                                                     </span>
                                                     <span style={{
                                                         color: '#718096',

--- a/frontend/src/components/Footer.js
+++ b/frontend/src/components/Footer.js
@@ -1,4 +1,5 @@
-﻿import React from 'react';
+import React from 'react';
+import Logo from './Logo';
 
 const Footer = ({ setCurrentView }) => {
     return (
@@ -17,22 +18,8 @@ const Footer = ({ setCurrentView }) => {
                 }}>
                     {/* Company Info */}
                     <div>
-                        <div style={{ display: 'flex', alignItems: 'center', gap: '0.5rem', marginBottom: '1rem' }}>
-                            <div style={{
-                                width: '32px',
-                                height: '32px',
-                                background: 'linear-gradient(135deg, #667eea 0%, #764ba2 100%)',
-                                borderRadius: '6px',
-                                display: 'flex',
-                                alignItems: 'center',
-                                justifyContent: 'center',
-                                color: 'white',
-                                fontWeight: 'bold',
-                                fontSize: '14px'
-                            }}>
-                                4¹
-                            </div>
-                            <span style={{ fontSize: '20px', fontWeight: 'bold' }}>Four Ones</span>
+                        <div style={{ marginBottom: '1rem' }}>
+                            <Logo size="large" />
                         </div>
                         <p style={{ color: '#a0aec0', marginBottom: '1rem', lineHeight: '1.6' }}>
                             Connecting amazing spaces with creative people worldwide. Turn your vision into reality with the perfect venue.

--- a/frontend/src/components/SpaceModal.js
+++ b/frontend/src/components/SpaceModal.js
@@ -1,6 +1,7 @@
-﻿import React, { useState, useCallback } from 'react';
+import React, { useState, useCallback } from 'react';
 import { GoogleMap, Marker, useJsApiLoader } from '@react-google-maps/api';
 import ServiceProviders from './ServiceProviders';
+import { formatCurrency } from '../utils/format';
 
 const MAPS_API_KEY = 'AIzaSyD31NAQXFlL4rW-nZtJEx6ImfjBQAtXoJ0';
 
@@ -145,22 +146,7 @@ const SpaceModal = ({ space, isOpen, onClose, setCurrentView, favorites, toggleF
                     justifyContent: 'space-between',
                     padding: '1rem'
                 }}>
-                    <button 
-                        onClick={handleModalClose}
-                        style={{
-                            background: 'rgba(0, 0, 0, 0.1)',
-                            border: 'none',
-                            borderRadius: '50%',
-                            width: '40px',
-                            height: '40px',
-                            cursor: 'pointer',
-                            fontSize: '1.5rem'
-                        }}
-                    >
-                        ×
-                    </button>
-
-                    <button 
+                    <button
                         onClick={(e) => {
                             e.stopPropagation();
                             toggleFavorite(space.id, e);
@@ -176,6 +162,21 @@ const SpaceModal = ({ space, isOpen, onClose, setCurrentView, favorites, toggleF
                         }}
                     >
                         {favorites?.includes(space.id) ? '❤️' : '🤍'}
+                    </button>
+
+                    <button
+                        onClick={handleModalClose}
+                        style={{
+                            background: 'rgba(0, 0, 0, 0.1)',
+                            border: 'none',
+                            borderRadius: '50%',
+                            width: '40px',
+                            height: '40px',
+                            cursor: 'pointer',
+                            fontSize: '1.5rem'
+                        }}
+                    >
+                        ×
                     </button>
                 </div>
 
@@ -217,11 +218,12 @@ const SpaceModal = ({ space, isOpen, onClose, setCurrentView, favorites, toggleF
                             {/* Image Gallery */}
                             <div className="image-gallery" style={{
                                 display: 'flex',
-                                overflowX: 'scroll',
+                                overflowX: 'auto',
                                 gap: '1rem',
                                 marginBottom: '1.5rem',
                                 paddingBottom: '1rem',
-                                scrollbarWidth: 'none' // Hide scrollbar for modern browsers
+                                scrollbarWidth: 'thin',
+                                WebkitOverflowScrolling: 'touch'
                             }}>
                                 {space.images && space.images.map((img, idx) => (
                                     <img
@@ -382,7 +384,7 @@ const SpaceModal = ({ space, isOpen, onClose, setCurrentView, favorites, toggleF
                                         }}
                                     >
                                         <div style={{ fontWeight: '600' }}>
-                                            ${Math.round(space.price * duration.multiplier)}
+                                            {formatCurrency(Math.round(space.price * duration.multiplier))}
                                         </div>
                                         <div style={{
                                             fontSize: '0.75rem',
@@ -424,15 +426,6 @@ const SpaceModal = ({ space, isOpen, onClose, setCurrentView, favorites, toggleF
                                             color: '#1a202c'
                                         }}
                                     />
-                                    <span style={{
-                                        position: 'absolute',
-                                        right: '1rem',
-                                        top: '50%',
-                                        transform: 'translateY(-50%)',
-                                        pointerEvents: 'none',
-                                        color: '#667eea',
-                                        fontSize: '1.3rem'
-                                    }}>📅</span>
                                 </div>
                                 <button
                                     onClick={handleBooking}

--- a/frontend/src/data/mockData.js
+++ b/frontend/src/data/mockData.js
@@ -5,6 +5,8 @@ export const mockSpaces = [
         category: "Gallery/Exhibition",
         location: "Auckland CBD",
         address: "123 Queen Street, Auckland CBD, Auckland 1010, New Zealand",
+        latitude: -36.8485,
+        longitude: 174.7633,
         price: 150,
         capacity: 50,
         images: [
@@ -21,6 +23,8 @@ export const mockSpaces = [
         category: "Workshop/Class Space",
         location: "Ponsonby",
         address: "456 Ponsonby Road, Ponsonby, Auckland 1011, New Zealand",
+        latitude: -36.8563,
+        longitude: 174.7447,
         price: 80,
         capacity: 20,
         images: [
@@ -36,6 +40,8 @@ export const mockSpaces = [
         category: "Retail Pop-Up",
         location: "Newmarket",
         address: "789 Broadway, Newmarket, Auckland 1023, New Zealand",
+        latitude: -36.877,
+        longitude: 174.783,
         price: 200,
         capacity: 30,
         images: [
@@ -51,6 +57,8 @@ export const mockSpaces = [
         category: "Workshop/Class Space",
         location: "Parnell",
         address: "321 Parnell Road, Parnell, Auckland 1052, New Zealand",
+        latitude: -36.8526,
+        longitude: 174.7897,
         price: 120,
         capacity: 25,
         images: [
@@ -66,6 +74,8 @@ export const mockSpaces = [
         category: "Event Hall",
         location: "Auckland CBD",
         address: "100 Federal Street, Auckland CBD, Auckland 1010, New Zealand",
+        latitude: -36.8485,
+        longitude: 174.7633,
         price: 300,
         capacity: 100,
         images: [
@@ -81,6 +91,8 @@ export const mockSpaces = [
         category: "Yoga/Wellness Studio",
         location: "Grey Lynn",
         address: "555 Great North Road, Grey Lynn, Auckland 1021, New Zealand",
+        latitude: -36.8667,
+        longitude: 174.7444,
         price: 90,
         capacity: 15,
         images: [
@@ -96,6 +108,8 @@ export const mockSpaces = [
         category: "Co-working",
         location: "Viaduct Harbour",
         address: "200 Quay Street, Viaduct Harbour, Auckland 1010, New Zealand",
+        latitude: -36.8418,
+        longitude: 174.758,
         price: 180,
         capacity: 40,
         images: [
@@ -111,6 +125,8 @@ export const mockSpaces = [
         category: "Pop-up Restaurant",
         location: "Wynyard Quarter",
         address: "150 Halsey Street, Wynyard Quarter, Auckland 1010, New Zealand",
+        latitude: -36.8411,
+        longitude: 174.7586,
         price: 250,
         capacity: 60,
         images: [
@@ -119,6 +135,431 @@ export const mockSpaces = [
         ],
         amenities: ["Commercial Kitchen", "Dining Area", "Liquor License", "Outdoor Seating"],
         rating: 4.6
+    },
+    {
+        id: 9,
+        title: "Wellington Creative Loft",
+        category: "Studio",
+        location: "Wellington",
+        address: "1 Cuba Street, Wellington, New Zealand",
+        latitude: -41.2865,
+        longitude: 174.7762,
+        price: 220,
+        capacity: 40,
+        images: [
+            "https://images.unsplash.com/photo-1529101091764-c3526daf38fe?w=600&h=400&fit=crop",
+            "https://images.unsplash.com/photo-1508921233553-20be7c3c02d1?w=600&h=400&fit=crop"
+        ],
+        amenities: ["WiFi", "Kitchen", "Parking"],
+        rating: 4.7
+    },
+    {
+        id: 10,
+        title: "Christchurch Conference Centre",
+        category: "Event Hall",
+        location: "Christchurch",
+        address: "100 Cathedral Square, Christchurch, New Zealand",
+        latitude: -43.5321,
+        longitude: 172.6362,
+        price: 350,
+        capacity: 150,
+        images: [
+            "https://images.unsplash.com/photo-1503424886307-b0903458393d?w=600&h=400&fit=crop",
+            "https://images.unsplash.com/photo-1515165562835-c7dfd66d8125?w=600&h=400&fit=crop"
+        ],
+        amenities: ["Stage", "AV Equipment", "Parking"],
+        rating: 4.8
+    },
+    {
+        id: 11,
+        title: "Queenstown Lakeside Venue",
+        category: "Outdoor/Event Space",
+        location: "Queenstown",
+        address: "12 Lake Esplanade, Queenstown, New Zealand",
+        latitude: -45.0312,
+        longitude: 168.6626,
+        price: 400,
+        capacity: 200,
+        images: [
+            "https://images.unsplash.com/photo-1502784444185-477d56b18033?w=600&h=400&fit=crop",
+            "https://images.unsplash.com/photo-1527515637462-df3600165b41?w=600&h=400&fit=crop"
+        ],
+        amenities: ["Scenic Views", "Outdoor Seating"],
+        rating: 4.9
+    },
+    {
+        id: 12,
+        title: "Hamilton Workshop Hub",
+        category: "Workshop/Class Space",
+        location: "Hamilton",
+        address: "50 Victoria Street, Hamilton, New Zealand",
+        latitude: -37.787,
+        longitude: 175.2793,
+        price: 120,
+        capacity: 30,
+        images: [
+            "https://images.unsplash.com/photo-1555529771-4e590145d1c2?w=600&h=400&fit=crop",
+            "https://images.unsplash.com/photo-1523473827532-6ac41e3a2f32?w=600&h=400&fit=crop"
+        ],
+        amenities: ["Tools", "Parking"],
+        rating: 4.5
+    },
+    {
+        id: 13,
+        title: "Tauranga Coastal Gallery",
+        category: "Gallery/Exhibition",
+        location: "Tauranga",
+        address: "5 The Strand, Tauranga, New Zealand",
+        latitude: -37.6878,
+        longitude: 176.1651,
+        price: 180,
+        capacity: 60,
+        images: [
+            "https://images.unsplash.com/photo-1503389152951-9f343605f61b?w=600&h=400&fit=crop",
+            "https://images.unsplash.com/photo-1529103891-b9e7d4f0ddee?w=600&h=400&fit=crop"
+        ],
+        amenities: ["WiFi", "Parking"],
+        rating: 4.6
+    },
+    {
+        id: 14,
+        title: "Dunedin Heritage Hall",
+        category: "Event Hall",
+        location: "Dunedin",
+        address: "1 Octagon, Dunedin, New Zealand",
+        latitude: -45.8788,
+        longitude: 170.5028,
+        price: 260,
+        capacity: 120,
+        images: [
+            "https://images.unsplash.com/photo-1526481280690-7c5c32733f83?w=600&h=400&fit=crop",
+            "https://images.unsplash.com/photo-1597076541077-01c2d613c23e?w=600&h=400&fit=crop"
+        ],
+        amenities: ["Stage", "AV Equipment", "Historic Building"],
+        rating: 4.7
+    },
+    {
+        id: 15,
+        title: "Nelson Art Studio",
+        category: "Studio",
+        location: "Nelson",
+        address: "23 Hardy Street, Nelson, New Zealand",
+        latitude: -41.2706,
+        longitude: 173.284,
+        price: 140,
+        capacity: 25,
+        images: [
+            "https://images.unsplash.com/photo-1516321165247-4aa89a48be28?w=600&h=400&fit=crop",
+            "https://images.unsplash.com/photo-1498075702571-ecb018f3752d?w=600&h=400&fit=crop"
+        ],
+        amenities: ["Natural Light", "Parking"],
+        rating: 4.5
+    },
+    {
+        id: 16,
+        title: "Napier Rooftop Space",
+        category: "Outdoor/Event Space",
+        location: "Napier",
+        address: "70 Marine Parade, Napier, New Zealand",
+        latitude: -39.4928,
+        longitude: 176.912,
+        price: 210,
+        capacity: 80,
+        images: [
+            "https://images.unsplash.com/photo-1504384308090-c894fdcc538d?w=600&h=400&fit=crop",
+            "https://images.unsplash.com/photo-1472653431158-6364773b2a56?w=600&h=400&fit=crop"
+        ],
+        amenities: ["Ocean View", "Bar"],
+        rating: 4.6
+    },
+    {
+        id: 17,
+        title: "Rotorua Wellness Retreat",
+        category: "Yoga/Wellness Studio",
+        location: "Rotorua",
+        address: "15 Arawa Street, Rotorua, New Zealand",
+        latitude: -38.1368,
+        longitude: 176.2497,
+        price: 130,
+        capacity: 20,
+        images: [
+            "https://images.unsplash.com/photo-1518611012118-fb36ba1c7040?w=600&h=400&fit=crop",
+            "https://images.unsplash.com/photo-1562078841-95cb5a3a01fb?w=600&h=400&fit=crop"
+        ],
+        amenities: ["Mats", "Changing Rooms"],
+        rating: 4.4
+    },
+    {
+        id: 18,
+        title: "New Plymouth Innovation Lab",
+        category: "Co-working",
+        location: "New Plymouth",
+        address: "30 Devon Street, New Plymouth, New Zealand",
+        latitude: -39.0556,
+        longitude: 174.0752,
+        price: 170,
+        capacity: 50,
+        images: [
+            "https://images.unsplash.com/photo-1507209696998-3c532be9b2b8?w=600&h=400&fit=crop",
+            "https://images.unsplash.com/photo-1484154218962-a197022b5858?w=600&h=400&fit=crop"
+        ],
+        amenities: ["WiFi", "Meeting Rooms"],
+        rating: 4.6
+    },
+    {
+        id: 19,
+        title: "Invercargill Event Centre",
+        category: "Event Hall",
+        location: "Invercargill",
+        address: "50 Tay Street, Invercargill, New Zealand",
+        latitude: -46.4132,
+        longitude: 168.3538,
+        price: 240,
+        capacity: 110,
+        images: [
+            "https://images.unsplash.com/photo-1542089363-532f5af0588a?w=600&h=400&fit=crop",
+            "https://images.unsplash.com/photo-1585241936939-3e5ff237aaab?w=600&h=400&fit=crop"
+        ],
+        amenities: ["Stage", "Parking"],
+        rating: 4.5
+    },
+    {
+        id: 20,
+        title: "Whangarei Harbour View",
+        category: "Outdoor/Event Space",
+        location: "Whangarei",
+        address: "12 Quayside, Whangarei, New Zealand",
+        latitude: -35.7251,
+        longitude: 174.3237,
+        price: 190,
+        capacity: 70,
+        images: [
+            "https://images.unsplash.com/photo-1523661149972-0becaca8d902?w=600&h=400&fit=crop",
+            "https://images.unsplash.com/photo-1506377247377-2a5b3b417ebb?w=600&h=400&fit=crop"
+        ],
+        amenities: ["Scenic Views"],
+        rating: 4.5
+    },
+    {
+        id: 21,
+        title: "Palmerston North Studio",
+        category: "Studio",
+        location: "Palmerston North",
+        address: "80 Fitzherbert Avenue, Palmerston North, New Zealand",
+        latitude: -40.3523,
+        longitude: 175.6082,
+        price: 110,
+        capacity: 20,
+        images: [
+            "https://images.unsplash.com/photo-1526318472351-bc78f0838f36?w=600&h=400&fit=crop",
+            "https://images.unsplash.com/photo-1532074205216-d0e1f4b87368?w=600&h=400&fit=crop"
+        ],
+        amenities: ["Parking", "Natural Light"],
+        rating: 4.3
+    },
+    {
+        id: 22,
+        title: "Hastings Market Hall",
+        category: "Retail Pop-Up",
+        location: "Hastings",
+        address: "120 Heretaunga Street, Hastings, New Zealand",
+        latitude: -39.6381,
+        longitude: 176.8495,
+        price: 160,
+        capacity: 45,
+        images: [
+            "https://images.unsplash.com/photo-1524758631624-e2822e304c36?w=600&h=400&fit=crop",
+            "https://images.unsplash.com/photo-1481349518771-20055b2a7b24?w=600&h=400&fit=crop"
+        ],
+        amenities: ["WiFi", "Storage"],
+        rating: 4.4
+    },
+    {
+        id: 23,
+        title: "Gisborne Sunlit Loft",
+        category: "Studio",
+        location: "Gisborne",
+        address: "40 Childers Road, Gisborne, New Zealand",
+        latitude: -38.6623,
+        longitude: 178.0176,
+        price: 130,
+        capacity: 25,
+        images: [
+            "https://images.unsplash.com/photo-1504470695779-75300268aa04?w=600&h=400&fit=crop",
+            "https://images.unsplash.com/photo-1523375481589-9b678a2eec16?w=600&h=400&fit=crop"
+        ],
+        amenities: ["WiFi", "Parking"],
+        rating: 4.4
+    },
+    {
+        id: 24,
+        title: "Blenheim Vineyard Venue",
+        category: "Outdoor/Event Space",
+        location: "Blenheim",
+        address: "1 Rapaura Road, Blenheim, New Zealand",
+        latitude: -41.5134,
+        longitude: 173.9612,
+        price: 300,
+        capacity: 150,
+        images: [
+            "https://images.unsplash.com/photo-1470071459604-3b5ec3a7fe05?w=600&h=400&fit=crop",
+            "https://images.unsplash.com/photo-1519682337058-a94d519337bc?w=600&h=400&fit=crop"
+        ],
+        amenities: ["Parking", "Scenic Views"],
+        rating: 4.8
+    },
+    {
+        id: 25,
+        title: "Timaru Community Hall",
+        category: "Event Hall",
+        location: "Timaru",
+        address: "60 Stafford Street, Timaru, New Zealand",
+        latitude: -44.3962,
+        longitude: 171.2541,
+        price: 150,
+        capacity: 90,
+        images: [
+            "https://images.unsplash.com/photo-1504384308090-c894fdcc538d?w=600&h=400&fit=crop",
+            "https://images.unsplash.com/photo-1523626797181-8c5ae80d40cb?w=600&h=400&fit=crop"
+        ],
+        amenities: ["Stage", "Parking"],
+        rating: 4.3
+    },
+    {
+        id: 26,
+        title: "Taupo Lakeside Retreat",
+        category: "Outdoor/Event Space",
+        location: "Taupo",
+        address: "3 Lake Terrace, Taupo, New Zealand",
+        latitude: -38.6857,
+        longitude: 176.0702,
+        price: 280,
+        capacity: 100,
+        images: [
+            "https://images.unsplash.com/photo-1501769214405-5e95b113fb56?w=600&h=400&fit=crop",
+            "https://images.unsplash.com/photo-1500530855697-b586d89ba3ee?w=600&h=400&fit=crop"
+        ],
+        amenities: ["Scenic Views", "Outdoor Seating"],
+        rating: 4.7
+    },
+    {
+        id: 27,
+        title: "Wanaka Alpine Lodge",
+        category: "Lodge",
+        location: "Wanaka",
+        address: "10 Ardmore Street, Wanaka, New Zealand",
+        latitude: -44.697,
+        longitude: 169.1358,
+        price: 320,
+        capacity: 60,
+        images: [
+            "https://images.unsplash.com/photo-1508612761958-e931b1b6ccaa?w=600&h=400&fit=crop",
+            "https://images.unsplash.com/photo-1525164283389-05b21425d3ee?w=600&h=400&fit=crop"
+        ],
+        amenities: ["Parking", "Scenic Views"],
+        rating: 4.9
+    },
+    {
+        id: 28,
+        title: "Kerikeri Garden Venue",
+        category: "Outdoor/Event Space",
+        location: "Kerikeri",
+        address: "15 Kerikeri Road, Kerikeri, New Zealand",
+        latitude: -35.2288,
+        longitude: 173.9481,
+        price: 210,
+        capacity: 80,
+        images: [
+            "https://images.unsplash.com/photo-1492684223066-81342ee5ff30?w=600&h=400&fit=crop",
+            "https://images.unsplash.com/photo-1469474968028-56623f02e42e?w=600&h=400&fit=crop"
+        ],
+        amenities: ["Garden", "Parking"],
+        rating: 4.5
+    },
+    {
+        id: 29,
+        title: "Greymouth Warehouse",
+        category: "Workshop/Class Space",
+        location: "Greymouth",
+        address: "2 Mawhera Quay, Greymouth, New Zealand",
+        latitude: -42.4507,
+        longitude: 171.2108,
+        price: 100,
+        capacity: 40,
+        images: [
+            "https://images.unsplash.com/photo-1581579184883-9b78abc42fdb?w=600&h=400&fit=crop",
+            "https://images.unsplash.com/photo-1581579886880-81de4c9cfe11?w=600&h=400&fit=crop"
+        ],
+        amenities: ["Tools", "Loading Dock"],
+        rating: 4.2
+    },
+    {
+        id: 30,
+        title: "Whanganui Historic Theatre",
+        category: "Event Hall",
+        location: "Whanganui",
+        address: "20 Victoria Avenue, Whanganui, New Zealand",
+        latitude: -39.9311,
+        longitude: 175.047,
+        price: 230,
+        capacity: 120,
+        images: [
+            "https://images.unsplash.com/photo-1521737852567-6949f3f9f2b5?w=600&h=400&fit=crop",
+            "https://images.unsplash.com/photo-1508614987232-1efcee1403ab?w=600&h=400&fit=crop"
+        ],
+        amenities: ["Stage", "AV Equipment"],
+        rating: 4.6
+    },
+    {
+        id: 31,
+        title: "Masterton Community Centre",
+        category: "Event Hall",
+        location: "Masterton",
+        address: "50 Queen Street, Masterton, New Zealand",
+        latitude: -40.9592,
+        longitude: 175.6574,
+        price: 150,
+        capacity: 70,
+        images: [
+            "https://images.unsplash.com/photo-1515169273891-0c260701e631?w=600&h=400&fit=crop",
+            "https://images.unsplash.com/photo-1470337458703-46ad1756a187?w=600&h=400&fit=crop"
+        ],
+        amenities: ["Parking", "Kitchen"],
+        rating: 4.4
+    },
+    {
+        id: 32,
+        title: "Cambridge Makers Space",
+        category: "Workshop/Class Space",
+        location: "Cambridge",
+        address: "70 Victoria Street, Cambridge, New Zealand",
+        latitude: -37.8916,
+        longitude: 175.4725,
+        price: 120,
+        capacity: 35,
+        images: [
+            "https://images.unsplash.com/photo-1515378791036-0648a3ef77b2?w=600&h=400&fit=crop",
+            "https://images.unsplash.com/photo-1505455184861-184e9204165e?w=600&h=400&fit=crop"
+        ],
+        amenities: ["Tools", "WiFi"],
+        rating: 4.3
+    },
+    {
+        id: 33,
+        title: "Oamaru Historic Warehouse",
+        category: "Retail Pop-Up",
+        location: "Oamaru",
+        address: "12 Tyne Street, Oamaru, New Zealand",
+        latitude: -45.097,
+        longitude: 170.9709,
+        price: 170,
+        capacity: 50,
+        images: [
+            "https://images.unsplash.com/photo-1508898578281-774ac4893f34?w=600&h=400&fit=crop",
+            "https://images.unsplash.com/photo-1502877338535-766e1452684a?w=600&h=400&fit=crop"
+        ],
+        amenities: ["Historic Building", "Storage"],
+        rating: 4.5
     }
 ];
 

--- a/frontend/src/pages/AuthForm.js
+++ b/frontend/src/pages/AuthForm.js
@@ -157,6 +157,7 @@ const AuthForm = ({ type, setCurrentView }) => {
                                 >
                                     <option value="hirer">Space Hirer</option>
                                     <option value="provider">Space Provider</option>
+                                    <option value="service">Service Provider</option>
                                 </select>
                             </div>
                         )}

--- a/frontend/src/pages/BrowseSpaces.js
+++ b/frontend/src/pages/BrowseSpaces.js
@@ -1,8 +1,11 @@
-﻿import React, { useState } from 'react';
+import React, { useState } from 'react';
 import SearchBar from '../components/SearchBar';
 import SpaceModal from '../components/SpaceModal';
 import { mockSpaces } from '../data/mockData';
 import { GoogleMap, Marker, useJsApiLoader } from '@react-google-maps/api';
+import { formatCurrency } from '../utils/format';
+
+const MAPS_API_KEY = 'AIzaSyD31NAQXFlL4rW-nZtJEx6ImfjBQAtXoJ0';
 
 const BrowseSpaces = ({ setCurrentView }) => {
     const [selectedSpace, setSelectedSpace] = useState(null);
@@ -53,64 +56,40 @@ const BrowseSpaces = ({ setCurrentView }) => {
         );
     };
 
-    const MapView = () => (
-        <div style={{
-            height: '600px',
-            backgroundColor: '#f0f0f0',
-            borderRadius: '12px',
-            display: 'flex',
-            alignItems: 'center',
-            justifyContent: 'center',
-            position: 'relative',
-            backgroundImage: 'url("data:image/svg+xml,%3Csvg width="20" height="20" viewBox="0 0 20 20" xmlns="http://www.w3.org/2000/svg"%3E%3Cg fill="%23e2e8f0" fill-opacity="0.4"%3E%3Ccircle cx="3" cy="3" r="3"/%3E%3Ccircle cx="13" cy="13" r="3"/%3E%3C/g%3E%3C/svg%3E")'
-        }}>
-            <div style={{
-                position: 'absolute',
-                top: '1rem',
-                right: '1rem',
-                backgroundColor: 'white',
-                padding: '0.5rem',
-                borderRadius: '8px',
-                boxShadow: '0 2px 8px rgba(0,0,0,0.1)',
-                fontSize: '0.875rem',
-                color: '#666'
-            }}>
-                🗺️ Google Maps integration would go here
-            </div>
+    const { isLoaded } = useJsApiLoader({
+        id: 'google-map-browse',
+        googleMapsApiKey: MAPS_API_KEY
+    });
 
-            {/* Mock map pins for spaces */}
-            {spaces.map((space, index) => (
-                <div
-                    key={space.id}
-                    onClick={() => handleSpaceClick(space)}
-                    style={{
-                        position: 'absolute',
-                        left: `${20 + (index * 15)}%`,
-                        top: `${30 + (index * 10)}%`,
-                        backgroundColor: '#667eea',
-                        color: 'white',
-                        padding: '0.5rem 1rem',
-                        borderRadius: '20px',
-                        cursor: 'pointer',
-                        fontSize: '0.875rem',
-                        fontWeight: '600',
-                        boxShadow: '0 4px 12px rgba(102, 126, 234, 0.4)',
-                        transform: 'scale(1)',
-                        transition: 'transform 0.2s ease, box-shadow 0.2s ease',
-                        animation: `fadeIn 0.6s ease ${index * 0.1}s both`
-                    }}
-                    onMouseEnter={(e) => {
-                        e.target.style.transform = 'scale(1.1)';
-                        e.target.style.boxShadow = '0 6px 16px rgba(102, 126, 234, 0.6)';
-                    }}
-                    onMouseLeave={(e) => {
-                        e.target.style.transform = 'scale(1)';
-                        e.target.style.boxShadow = '0 4px 12px rgba(102, 126, 234, 0.4)';
-                    }}
-                >
-                    📍 ${space.price}/day
+    const MapView = () => (
+        <div style={{ height: '600px' }}>
+            {!isLoaded ? (
+                <div style={{
+                    height: '100%',
+                    display: 'flex',
+                    alignItems: 'center',
+                    justifyContent: 'center',
+                    backgroundColor: '#f0f0f0',
+                    borderRadius: '12px'
+                }}>
+                    Loading map...
                 </div>
-            ))}
+            ) : (
+                <GoogleMap
+                    mapContainerStyle={{ height: '100%', width: '100%', borderRadius: '12px' }}
+                    center={{ lat: spaces[0]?.latitude || -41.2865, lng: spaces[0]?.longitude || 174.7762 }}
+                    zoom={5}
+                    options={{ fullscreenControl: false, streetViewControl: false, mapTypeControl: false }}
+                >
+                    {spaces.map(space => (
+                        <Marker
+                            key={space.id}
+                            position={{ lat: space.latitude || -41.2865, lng: space.longitude || 174.7762 }}
+                            onClick={() => handleSpaceClick(space)}
+                        />
+                    ))}
+                </GoogleMap>
+            )}
         </div>
     );
 
@@ -384,7 +363,7 @@ const BrowseSpaces = ({ setCurrentView }) => {
                                                 color: '#1a202c',
                                                 fontFamily: 'Inter, sans-serif'
                                             }}>
-                                                ${space.price}
+                                            {formatCurrency(space.price)}
                                             </span>
                                             <span style={{
                                                 color: '#718096',
@@ -412,19 +391,19 @@ const BrowseSpaces = ({ setCurrentView }) => {
                                         marginBottom: '1rem'
                                     }}>
                                         <div style={{ padding: '0.5rem', backgroundColor: '#fef5e7', borderRadius: '6px', color: '#92400e' }}>
-                                            <div style={{ fontWeight: '600' }}>${Math.round(space.price / 8)}</div>
+                                            <div style={{ fontWeight: '600' }}>{formatCurrency(Math.round(space.price / 8))}</div>
                                             <div>per hour</div>
                                         </div>
                                         <div style={{ padding: '0.5rem', backgroundColor: '#eff6ff', borderRadius: '6px', color: '#1e40af' }}>
-                                            <div style={{ fontWeight: '600' }}>${space.price}</div>
+                                            <div style={{ fontWeight: '600' }}>{formatCurrency(space.price)}</div>
                                             <div>per day</div>
                                         </div>
                                         <div style={{ padding: '0.5rem', backgroundColor: '#f0fdf4', borderRadius: '6px', color: '#166534' }}>
-                                            <div style={{ fontWeight: '600' }}>${space.price * 25}</div>
+                                            <div style={{ fontWeight: '600' }}>{formatCurrency(space.price * 25)}</div>
                                             <div>per month</div>
                                         </div>
                                         <div style={{ padding: '0.5rem', backgroundColor: '#fdf2f8', borderRadius: '6px', color: '#be185d' }}>
-                                            <div style={{ fontWeight: '600' }}>${space.price * 300}</div>
+                                            <div style={{ fontWeight: '600' }}>{formatCurrency(space.price * 300)}</div>
                                             <div>per year</div>
                                         </div>
                                     </div>

--- a/frontend/src/pages/HowItWorks.js
+++ b/frontend/src/pages/HowItWorks.js
@@ -23,7 +23,7 @@ const HowItWorks = ({ setCurrentView }) => {
                     <p style={{ fontSize: '1.2rem', color: '#666' }}>Simple steps to find or list your perfect space</p>
                 </div>
 
-                <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: '4rem', marginBottom: '4rem' }}>
+                <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(280px, 1fr))', gap: '4rem', marginBottom: '4rem' }}>
                     {/* For Space Hirers */}
                     <div>
                         <h2 style={{ fontSize: '2rem', marginBottom: '2rem', color: '#667eea' }}>For Space Hirers</h2>

--- a/frontend/src/utils/format.js
+++ b/frontend/src/utils/format.js
@@ -1,0 +1,3 @@
+export const formatCurrency = (value) => {
+  return value.toLocaleString('en-NZ', { style: 'currency', currency: 'NZD', maximumFractionDigits: 0 });
+};


### PR DESCRIPTION
## Summary
- show currency with commas via `formatCurrency`
- integrate real Google maps on browse page
- make gallery scrolling work on desktop and swap favorite/close buttons
- unify footer logo with header logo
- allow service provider signup
- tweak layout on How It Works page
- seed many NZ example spaces with coordinates

## Testing
- `npm test --silent` *(fails: react-scripts Permission denied)*
- `npm run build --silent` *(fails: react-scripts Permission denied)*

------
https://chatgpt.com/codex/tasks/task_e_686396d83c94832d9b2fa44d4a667ff1